### PR TITLE
Add a terminate function to IsoMdlPresentation for interrupted sessions

### DIFF
--- a/MobileSdk/src/main/java/com/spruceid/mobile/sdk/IsoMdlPresentation.kt
+++ b/MobileSdk/src/main/java/com/spruceid/mobile/sdk/IsoMdlPresentation.kt
@@ -78,6 +78,10 @@ class IsoMdlPresentation(
         }
     }
 
+    fun terminate() {
+        this.bleManager!!.terminate()
+    }
+
     fun updateRequestData(data: ByteArray) {
         try {
             this.itemsRequests = session!!.handleRequest(data)


### PR DESCRIPTION
An oversight in creating this API. Since IsoMdlPresentation is holding the reference to the BLE transport object, it needs to expose a method for terminating the transmission mid-stream.